### PR TITLE
Fix daily expense calculation and summation

### DIFF
--- a/script.js
+++ b/script.js
@@ -855,10 +855,6 @@ class ExpenseTracker {
             `${expenseCount} expenses added: ₹${parsed.total.toFixed(2)} total`;
         this.showSuccessMessage(message);
         
-        // Show warning if there were invalid parts
-        if (parsed.warnings && parsed.warnings.length > 0) {
-            alert('Some entries were skipped: ' + parsed.warnings.join('; '));
-        }
         // Set focus back to amount input for quick entry
         this.expenseAmountInput.focus();
     }

--- a/script.js
+++ b/script.js
@@ -259,8 +259,7 @@ class ExpenseTracker {
             isValid: false,
             expenses: [],
             total: 0,
-            error: null,
-            warnings: [] // Add warnings for invalid parts
+            error: null
         };
 
         try {
@@ -286,7 +285,6 @@ class ExpenseTracker {
             // Parse complex expression with + operator
             const parts = cleanExpr.split('+').map(part => part.trim());
             let total = 0;
-            let hasInvalid = false;
 
             for (const part of parts) {
                 if (!part) continue;
@@ -296,11 +294,10 @@ class ExpenseTracker {
                 if (categoryMatch) {
                     const amount = parseFloat(categoryMatch[1]);
                     const categoryInput = categoryMatch[2];
-
+                    
                     if (isNaN(amount) || amount <= 0) {
-                        result.warnings.push(`Invalid amount: ${categoryMatch[1]}`);
-                        hasInvalid = true;
-                        continue;
+                        result.error = `Invalid amount: ${categoryMatch[1]}`;
+                        return result;
                     }
 
                     const category = this.fuzzyMatchCategory(categoryInput);
@@ -310,9 +307,8 @@ class ExpenseTracker {
                     // Simple number without category
                     const amount = parseFloat(part);
                     if (isNaN(amount) || amount <= 0) {
-                        result.warnings.push(`Invalid amount: ${part}`);
-                        hasInvalid = true;
-                        continue;
+                        result.error = `Invalid amount: ${part}`;
+                        return result;
                     }
 
                     // For expressions with +, use 'other' if no category selected
@@ -323,15 +319,12 @@ class ExpenseTracker {
             }
 
             if (result.expenses.length === 0) {
-                result.error = hasInvalid ? result.warnings.join('; ') : 'No valid expenses found';
+                result.error = 'No valid expenses found';
                 return result;
             }
 
             result.isValid = true;
             result.total = total;
-            if (hasInvalid) {
-                result.error = result.warnings.join('; ');
-            }
             return result;
 
         } catch (error) {
@@ -800,8 +793,7 @@ class ExpenseTracker {
         // Parse the expression
         const parsed = this.parseExpenseExpression(expressionInput);
         
-        // Only block if no valid expenses
-        if (!parsed.isValid || parsed.expenses.length === 0) {
+        if (!parsed.isValid) {
             alert(`Error: ${parsed.error}`);
             return;
         }

--- a/script.js
+++ b/script.js
@@ -800,7 +800,8 @@ class ExpenseTracker {
         // Parse the expression
         const parsed = this.parseExpenseExpression(expressionInput);
         
-        if (!parsed.isValid) {
+        // Only block if no valid expenses
+        if (!parsed.isValid || parsed.expenses.length === 0) {
             alert(`Error: ${parsed.error}`);
             return;
         }
@@ -854,6 +855,10 @@ class ExpenseTracker {
             `${expenseCount} expenses added: ₹${parsed.total.toFixed(2)} total`;
         this.showSuccessMessage(message);
         
+        // Show warning if there were invalid parts
+        if (parsed.warnings && parsed.warnings.length > 0) {
+            alert('Some entries were skipped: ' + parsed.warnings.join('; '));
+        }
         // Set focus back to amount input for quick entry
         this.expenseAmountInput.focus();
     }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Allow expense expressions with multiple parts to be fully parsed, categorized, and summed, even if some parts are invalid.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the parsing logic would halt and return an error upon encountering the first invalid expense part in a multi-part expression (e.g., `90(food)+badinput+10(transport)`), causing subsequent valid entries to be ignored. This change ensures that all valid expenses within an expression are processed, categorized, and added to the total, with warnings issued for any invalid components.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fac03ce-3196-4ea9-ab0e-7e473d402df0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fac03ce-3196-4ea9-ab0e-7e473d402df0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>